### PR TITLE
Add support for scaling recordings

### DIFF
--- a/src/animated-png-recorder.ts
+++ b/src/animated-png-recorder.ts
@@ -1,4 +1,4 @@
-import { createCanvas, getCanvasCtx2D } from "./util.js";
+import { FrameScaler } from "./frame-scaler.js";
 
 type UPNG = typeof import("../vendor/upng");
 
@@ -118,32 +118,5 @@ export class AnimatedPngRecorder {
       reader.onerror = reject;
       reader.readAsDataURL(blob);
     });
-  }
-}
-
-class FrameScaler {
-  readonly canvas: HTMLCanvasElement;
-  readonly ctx: CanvasRenderingContext2D;
-  readonly scaledCanvas: HTMLCanvasElement;
-  readonly scaledCtx: CanvasRenderingContext2D;
-  public readonly scaledHeight: number;
-  public readonly scaledWidth: number;
-
-  constructor(readonly width: number, readonly height: number, readonly scaleFactor: number) {
-    this.scaledWidth = width * scaleFactor;
-    this.scaledHeight = height * scaleFactor;
-    this.canvas = createCanvas(width, height);
-    this.scaledCanvas = createCanvas(this.scaledWidth, this.scaledHeight);
-    this.ctx = getCanvasCtx2D(this.canvas);
-    this.ctx.imageSmoothingEnabled = false;
-    this.scaledCtx = getCanvasCtx2D(this.scaledCanvas);
-    this.scaledCtx.imageSmoothingEnabled = false;
-    this.scale = this.scale.bind(this);
-  }
-
-  scale(frame: Uint8ClampedArray): Uint8ClampedArray {
-    this.ctx.putImageData(new ImageData(frame, this.width, this.height), 0, 0);
-    this.scaledCtx.drawImage(this.canvas, 0, 0, this.scaledWidth, this.scaledHeight);
-    return this.scaledCtx.getImageData(0, 0, this.scaledWidth, this.scaledHeight).data;
   }
 }

--- a/src/frame-scaler.ts
+++ b/src/frame-scaler.ts
@@ -1,0 +1,39 @@
+import { createCanvas, getCanvasCtx2D } from "./util.js";
+
+export class FrameScaler {
+  readonly canvases?: {
+    canvas: HTMLCanvasElement;
+    ctx: CanvasRenderingContext2D;
+    scaledCanvas: HTMLCanvasElement;
+    scaledCtx: CanvasRenderingContext2D;
+  };
+  public readonly scaledHeight: number;
+  public readonly scaledWidth: number;
+
+  constructor(readonly width: number, readonly height: number, readonly scaleFactor: number) {
+    this.scaledWidth = width * scaleFactor;
+    this.scaledHeight = height * scaleFactor;
+
+    if (scaleFactor !== 1) {
+      const canvas = createCanvas(width, height);
+      const scaledCanvas = createCanvas(this.scaledWidth, this.scaledHeight);
+      const ctx = getCanvasCtx2D(canvas);
+      ctx.imageSmoothingEnabled = false;
+      const scaledCtx = getCanvasCtx2D(scaledCanvas);
+      scaledCtx.imageSmoothingEnabled = false;
+      this.canvases = {canvas, scaledCanvas, ctx, scaledCtx};
+    }
+
+    this.scale = this.scale.bind(this);
+  }
+
+  scale(frame: Uint8ClampedArray): Uint8ClampedArray {
+    if (this.canvases) {
+      const { ctx, scaledCtx, canvas } = this.canvases;
+      ctx.putImageData(new ImageData(frame, this.width, this.height), 0, 0);
+      scaledCtx.drawImage(canvas, 0, 0, this.scaledWidth, this.scaledHeight);
+      return scaledCtx.getImageData(0, 0, this.scaledWidth, this.scaledHeight).data;
+    }
+    return frame;
+  }
+}

--- a/src/recorder-ui.ts
+++ b/src/recorder-ui.ts
@@ -1,5 +1,7 @@
 import { AnimatedPngRecorder } from "./animated-png-recorder.js";
 
+const SCALE_FACTOR = 2;
+
 export class RecorderUI {
   readonly recorder = new AnimatedPngRecorder();
   readonly overlayEl: HTMLDivElement;
@@ -29,7 +31,7 @@ export class RecorderUI {
       buttonEl.disabled = true;
       buttonEl.textContent = "Encoding\u2026";
       const { frameCount } = this.recorder;
-      const { url, byteLength } = await this.recorder.encodeToDataURL();
+      const { url, byteLength } = await this.recorder.encodeToDataURL(SCALE_FACTOR);
       this.url = url;
       buttonEl.title = `Final recording is ${frameCount} frames (${byteLength} bytes).`;
       buttonEl.textContent = `Open recording`;

--- a/src/recorder-ui.ts
+++ b/src/recorder-ui.ts
@@ -1,6 +1,6 @@
 import { AnimatedPngRecorder } from "./animated-png-recorder.js";
 
-const SCALE_FACTOR = 2;
+const SCALE_FACTOR = 1;
 
 export class RecorderUI {
   readonly recorder = new AnimatedPngRecorder();


### PR DESCRIPTION
This adds support for scaling the resolution of recordings, but it is slooooow.  It seems it's actually the encoding process that is slow though, not the actual scaling.  It also results in much larger animated PNGs, which I dislike.

Because of these issues, I'm just defaulting the scale to 1 for now, but this can be changed in the `SCALE_FACTOR` constant in `recorder-ui.ts`.